### PR TITLE
feat(product): add navigation and photo upload functionality

### DIFF
--- a/client/src/components/ProductCardAdmin/index.tsx
+++ b/client/src/components/ProductCardAdmin/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import {ProductCard} from '@/components'
+import {ProductCard} from '@/components';
 import { Button } from '@mui/material';
+import Link from 'next/link'; 
 
 interface Props{
     name: string;
@@ -20,13 +21,14 @@ const ProductCardAdmin: React.FC<Props> = ({ name, price, discount, image, onCli
             image={image}
             onClick={onClick}
             />
-
+            <Link href="/product/edit?id=1" passHref>
             <Button variant="contained" 
         
         sx={{ backgroundColor:"black", display: 'block', margin: '10px auto'}} // Centering the button
       >
                 EDITAR PRODUTO
             </Button>
+            </Link>
             <Button variant="contained" 
         color="primary" 
         sx={{ display: 'block'}}>

--- a/client/src/components/ProductForm/index.tsx
+++ b/client/src/components/ProductForm/index.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { TextField, Button, Box, Typography, MenuItem, Select, InputLabel, FormControl, IconButton } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { useRouter } from 'next/router';
+
+const ProductForm: React.FC<{ onSubmit: (data: any) => void, edit?: boolean }> = ({ onSubmit, edit = false }) => {
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    price: '',
+    status: false,
+    category: '',
+  });
+
+  const router = useRouter();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | { name?: string; value: unknown }>) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name as string]: value });
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onSubmit({
+      ...formData,
+      price: parseFloat(formData.price),
+    });
+    // Navegar para a página de upload da foto com o parâmetro de origem
+    router.push(`/product/uploadPhoto?origin=${edit ? 'edit' : 'create'}`);
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ backgroundColor: 'white', mt: 4, p: 4, borderRadius: 1, boxShadow: 3, maxWidth: 600, mx: 'auto' }}>
+      <Box display="flex" alignItems="center" mb={2}>
+        <IconButton 
+          onClick={() => router.back()} 
+          sx={{ 
+            mr: 2, 
+            color: 'black', 
+            '&:hover': {
+              backgroundColor: 'rgba(0, 0, 0, 0.1)', // Cor de fundo ao passar o mouse
+            }
+          }}
+        >
+          <ArrowBackIcon />
+        </IconButton>
+      </Box>
+      <Box display="flex" justifyContent="space-between" gap={2}>
+        <TextField
+          name="name"
+          label="Nome"
+          value={formData.name}
+          onChange={handleChange}
+          fullWidth
+          margin="normal"
+        />
+        <TextField
+          name="description"
+          label="Descrição"
+          value={formData.description}
+          onChange={handleChange}
+          fullWidth
+          margin="normal"
+        />
+      </Box>
+      <Box display="flex" justifyContent="space-between" gap={2}>
+        <TextField
+          name="price"
+          label="Valor"
+          value={formData.price}
+          onChange={handleChange}
+          fullWidth
+          margin="normal"
+        />
+        <TextField
+          name="category"
+          label="Categoria"
+          value={formData.category}
+          onChange={handleChange}
+          fullWidth
+          margin="normal"
+        />
+      </Box>
+      <FormControl fullWidth margin="normal">
+        <InputLabel>Disponível</InputLabel>
+        <Select
+          name="status"
+          value={formData.status}
+          onChange={handleChange}
+        >
+          <MenuItem value={true}>Sim</MenuItem>
+          <MenuItem value={false}>Não</MenuItem>
+        </Select>
+      </FormControl>
+      <Box textAlign="center" mt={4}>
+        <Button type="submit" variant="contained" sx={{ backgroundColor: "black", color: "white" }}>
+          PRÓXIMO
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default ProductForm;

--- a/client/src/pages/product/create.tsx
+++ b/client/src/pages/product/create.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Link from 'next/link';
+import { Box, Typography, Container, Button } from '@mui/material';
+import ProductForm from '@/components/ProductForm';
+
+const CreateProductPage: React.FC = () => {
+  const handleSubmit = (data: any) => {
+    console.log('Produto cadastrado:', data);
+    // Adicione a lógica para salvar o produto
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box mt={4}>
+        <Typography 
+          variant="h4" 
+          gutterBottom 
+          sx={{ 
+            backgroundColor: 'white', 
+            borderRadius: 2, // Adiciona curvas nas bordas
+            padding: 2, // Adiciona espaçamento interno
+            textAlign: 'center' // Centraliza o texto
+          }}
+        >
+          Cadastrar Produto
+        </Typography>
+        <ProductForm onSubmit={handleSubmit} />
+        <Box mt={4} textAlign="center">
+          <Link href="/product/edit?id=1" passHref> {/* Exemplo com ID estático */}
+            <Button variant="contained" color="secondary">
+              Ir para Edição de Produto
+            </Button>
+          </Link>
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default CreateProductPage;

--- a/client/src/pages/product/edit.tsx
+++ b/client/src/pages/product/edit.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { Box, Typography, Container } from '@mui/material';
+import ProductForm from '@/components/ProductForm';
+
+// Simulação de dados do produto para edição
+const mockProductData = {
+  id: '1',
+  name: 'Produto Exemplo',
+  description: 'Descrição do produto exemplo',
+  price: '100.00',
+  status: true,
+  category: { name: 'Categoria Exemplo' },
+};
+
+const EditProductPage: React.FC = () => {
+  const router = useRouter();
+  const { id } = router.query;
+  const [productData, setProductData] = useState<any>(null);
+
+  useEffect(() => {
+    if (id) {
+      // Aqui você pode buscar os dados do produto
+      setProductData(mockProductData);
+    }
+  }, [id]);
+
+  const handleSubmit = (data: any) => {
+    console.log('Produto editado:', data);
+    // Adicione a lógica para atualizar o produto
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box mt={4}>
+        <Typography variant="h4" 
+          gutterBottom 
+          sx={{ 
+            backgroundColor: 'white', 
+            borderRadius: 2, // Adiciona curvas nas bordas
+            padding: 2, // Adiciona espaçamento interno
+            textAlign: 'center' // Centraliza o texto
+          }}>
+          Editar Produto
+        </Typography>
+        {productData ? (
+          <ProductForm onSubmit={handleSubmit} edit />
+        ) : (
+          <p>Carregando...</p>
+        )}
+      </Box>
+    </Container>
+  );
+};
+
+export default EditProductPage;

--- a/client/src/pages/product/index.tsx
+++ b/client/src/pages/product/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Button, Typography, Modal } from '@mui/material';
 import ProductCarousel from '@/components/ProductCarouselAdmin';
+import Link from 'next/link'; 
 
 
 const ProductPage: React.FC = () => {
@@ -8,6 +9,7 @@ const ProductPage: React.FC = () => {
     <Box>
       <Typography variant="h4" gutterBottom>Produtos</Typography>
       <ProductCarousel />
+      <Link href="/product/create" passHref>
       <Button 
         variant="contained" 
         color="primary" 
@@ -15,6 +17,7 @@ const ProductPage: React.FC = () => {
       >
         Cadastrar Produto
       </Button>
+      </Link>
     
     </Box>
   );

--- a/client/src/pages/product/uploadPhoto.tsx
+++ b/client/src/pages/product/uploadPhoto.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import { Box, Typography, Container, Button } from '@mui/material';
+
+const UploadPhotoPage: React.FC = () => {
+  const router = useRouter();
+  const { origin } = router.query;
+
+  const handleUpload = () => {
+    console.log('Foto enviada!');
+    // Adicione a lógica para enviar a foto
+  };
+
+  const handleSave = () => {
+    console.log('Produto salvo!');
+    // Adicione a lógica para salvar o produto
+  };
+
+  const handleDelete = () => {
+    console.log('Produto excluído!');
+    // Adicione a lógica para excluir o produto
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box mt={4}>
+        <Typography variant="h4" 
+          gutterBottom 
+          sx={{ 
+            backgroundColor: 'white', 
+            borderRadius: 2, // Adiciona curvas nas bordas
+            padding: 2, // Adiciona espaçamento interno
+            textAlign: 'center' // Centraliza o texto
+          }}>
+          Upload da Foto do Produto
+        </Typography>
+        <Box mt={4} textAlign="center">
+          <input type="file" accept="image/*" />
+          <Button variant="contained" color="primary" onClick={handleUpload} sx={{ mt: 2 }}>
+            Enviar Foto
+          </Button>
+          {origin === 'create' ? (
+            <Button variant="contained" color="success" onClick={handleSave} sx={{ mt: 2 }}>
+              Cadastrar Produto
+            </Button>
+          ) : (
+            <Box mt={2}>
+              <Button variant="contained" color="success" onClick={handleSave} sx={{ mr: 2 }}>
+                Salvar Produto
+              </Button>
+              <Button variant="contained" color="error" onClick={handleDelete}>
+                Excluir Produto
+              </Button>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Container>
+  );
+};
+
+export default UploadPhotoPage;


### PR DESCRIPTION
# What I did:
- Add parameter to differentiate between create and edit in ProductForm
- Create UploadPhotoPage with conditional buttons based on origin
- Update CreateProductPage to navigate to UploadPhotoPage
- Update EditProductPage to navigate to UploadPhotoPage
- Add conditional rendering of buttons in UploadPhotoPage

## How to Test (Locate and See the Changes):

### Add parameter to differentiate between create and edit in ProductForm:
step 1: Open `ProductForm.tsx` and check the `handleSubmit` function for the new `origin` parameter.
step 2: Ensure that the `edit` prop is passed correctly from `EditProductPage`.

### Create UploadPhotoPage with conditional buttons based on origin:
step 1: Navigate to `/product/uploadPhoto?origin=create` and verify the "Cadastrar Produto" button is displayed.
step 2: Navigate to `/product/uploadPhoto?origin=edit` and verify the "Salvar Produto" and "Excluir Produto" buttons are displayed.

### Update CreateProductPage to navigate to UploadPhotoPage:
step 1: Open `CreateProductPage` and submit the form.
step 2: Verify that it redirects to `/product/uploadPhoto?origin=create`.

### Update EditProductPage to navigate to UploadPhotoPage:
step 1: Open `EditProductPage` and submit the form.
step 2: Verify that it redirects to `/product/uploadPhoto?origin=edit`.

### Add conditional rendering of buttons in UploadPhotoPage:
step 1: Check the `UploadPhotoPage.tsx` for conditional rendering based on the `origin` query parameter.
step 2: Ensure that the correct buttons are displayed based on the `origin` value.
"